### PR TITLE
[WIP] isolate: io.WriteCloser is used to notify runtime

### DIFF
--- a/isolate/d_test.go
+++ b/isolate/d_test.go
@@ -60,7 +60,7 @@ func (b *testBox) Spool(ctx context.Context, name string, opts Profile) error {
 	}
 }
 
-func (b *testBox) Spawn(ctx context.Context, config SpawnConfig, wr io.Writer) (Process, error) {
+func (b *testBox) Spawn(ctx context.Context, config SpawnConfig, wr io.WriteCloser) (Process, error) {
 	return spawnTestProcess(ctx, wr), nil
 }
 

--- a/isolate/docker/box.go
+++ b/isolate/docker/box.go
@@ -192,7 +192,7 @@ func (b *Box) Close() error {
 }
 
 // Spawn spawns a prcess using container
-func (b *Box) Spawn(ctx context.Context, config isolate.SpawnConfig, output io.Writer) (isolate.Process, error) {
+func (b *Box) Spawn(ctx context.Context, config isolate.SpawnConfig, output io.WriteCloser) (isolate.Process, error) {
 	profile, err := convertProfile(config.Opts)
 	if err != nil {
 		apexctx.GetLogger(ctx).WithError(err).WithFields(log.Fields{"name": config.Name}).Info("unable to convert raw profile to Docker specific profile")

--- a/isolate/docker/container.go
+++ b/isolate/docker/container.go
@@ -129,7 +129,7 @@ func newContainer(ctx context.Context, client *client.Client, profile *Profile, 
 	return pr, nil
 }
 
-func (p *process) startContainer(wr io.Writer) error {
+func (p *process) startContainer(wr io.WriteCloser) error {
 	var startBarier = make(chan struct{})
 	go p.collectOutput(startBarier, wr)
 	if err := p.client.ContainerStart(p.ctx, p.containerID, ""); err != nil {
@@ -158,7 +158,9 @@ func (p *process) remove() {
 	containerRemove(p.client, p.ctx, p.containerID)
 }
 
-func (p *process) collectOutput(started chan struct{}, writer io.Writer) {
+func (p *process) collectOutput(started chan struct{}, writer io.WriteCloser) {
+	// NOTE: It means that either Docker downs or a worker
+	defer writer.Close()
 	attachOpts := types.ContainerAttachOptions{
 		Stream: true,
 		Stdin:  false,

--- a/isolate/initialdispatch.go
+++ b/isolate/initialdispatch.go
@@ -251,6 +251,7 @@ type OutputCollector struct {
 
 	flagKilled *uint32
 	notified   uint32
+	closed     uint32
 }
 
 func (o *OutputCollector) Write(p []byte) (int, error) {
@@ -268,4 +269,12 @@ func (o *OutputCollector) Write(p []byte) (int, error) {
 
 	o.stream.Write(o.ctx, replySpawnWrite, p)
 	return len(p), nil
+}
+
+func (o *OutputCollector) Close() error {
+	if atomic.CompareAndSwapUint32(&o.closed, 0, 1) && atomic.LoadUint32(o.flagKilled) == 0 {
+		o.stream.Close(o.ctx, replyKillOk)
+	}
+
+	return nil
 }

--- a/isolate/isolate.go
+++ b/isolate/isolate.go
@@ -19,7 +19,7 @@ type (
 
 	Box interface {
 		Spool(ctx context.Context, name string, opts Profile) error
-		Spawn(ctx context.Context, config SpawnConfig, output io.Writer) (Process, error)
+		Spawn(ctx context.Context, config SpawnConfig, output io.WriteCloser) (Process, error)
 		Close() error
 	}
 

--- a/isolate/process/box.go
+++ b/isolate/process/box.go
@@ -156,7 +156,7 @@ func (b *Box) wait() {
 }
 
 // Spawn spawns a new process
-func (b *Box) Spawn(ctx context.Context, config isolate.SpawnConfig, output io.Writer) (isolate.Process, error) {
+func (b *Box) Spawn(ctx context.Context, config isolate.SpawnConfig, output io.WriteCloser) (isolate.Process, error) {
 	spoolPath := b.spoolPath
 	if val, ok := config.Opts["spool"]; ok {
 		spoolPath = fmt.Sprintf("%s", val)

--- a/isolate/process/proc_bench_test.go
+++ b/isolate/process/proc_bench_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -11,6 +12,14 @@ import (
 
 	"github.com/noxiouz/stout/isolate"
 )
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error {
+	return nil
+}
 
 func BenchmarkSpawnSeq(b *testing.B) {
 	spoolDir, err := ioutil.TempDir("", "example")
@@ -44,7 +53,7 @@ func BenchmarkSpawnSeq(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		p, err := box.Spawn(ctx, config, ioutil.Discard)
+		p, err := box.Spawn(ctx, config, nopCloser{ioutil.Discard})
 		if err != nil {
 			b.Fatal("Spawn error: ", err)
 		}
@@ -85,7 +94,7 @@ func BenchmarkSpawnParallel(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			p, err := box.Spawn(ctx, config, ioutil.Discard)
+			p, err := box.Spawn(ctx, config, nopCloser{ioutil.Discard})
 			if err != nil {
 				b.Fatal("Spawn error: ", err)
 			}

--- a/isolate/testsuite/boxsuite.go
+++ b/isolate/testsuite/boxsuite.go
@@ -57,6 +57,14 @@ func (suite *BoxSuite) TearDownSuite(c *check.C) {
 	}
 }
 
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error {
+	return nil
+}
+
 // TestSpawn spool code, spawns special worker.sh to verify if env and args are set correctly and
 // output is collected properly
 func (suite *BoxSuite) TestSpawn(c *check.C) {
@@ -89,7 +97,7 @@ func (suite *BoxSuite) TestSpawn(c *check.C) {
 	}
 
 	body := new(bytes.Buffer)
-	pr, err := suite.Box.Spawn(ctx, config, body)
+	pr, err := suite.Box.Spawn(ctx, config, nopCloser{body})
 	c.Assert(err, check.IsNil)
 	// TODO: add synchronized writer
 	time.Sleep(5 * time.Second)


### PR DESCRIPTION
about worker's death

UP: this fix leads to

```
     0, 2016-07-19 09:54:24.610726: slave has changed its state from 'handshaking' to 'closed' :: uuid: 04059941-02ed-448d-a345-ef48a6e8c99b, source: echo/slave
      0, 2016-07-19 09:54:24.610804: slave has removed itself from the pool :: source: echo/overseer
Assertion failed: (ec), function terminate, file /Users/noxiouz/Documents/github/cocaine-plugins/node/src/node/slave/machine.cpp, line 230.
```
