### PR TITLE
add internal lock when we get mtn ip allocation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-isolate-daemon (0.2.1.3) unstable; urgency=low
+
+  * mtn: fix possible raise when call UseAlloc()
+
+ -- Dmitriy Karpukhin <dmitriy.karpukhin@gmail.com>  Tue, 12 Feb 2019 14:42:33 +0300
+
 cocaine-isolate-daemon (0.2.1.2) unstable; urgency=low
 
   * mtn: add more logging for mtn

--- a/isolate/mtn.go
+++ b/isolate/mtn.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 	bolt "go.etcd.io/bbolt"
 	"github.com/noxiouz/stout/pkg/log"
@@ -52,6 +53,7 @@ type MtnCfg struct {
 }
 
 type MtnState struct {
+	AllocMu sync.Mutex
 	Cfg MtnCfg
 	Db *bolt.DB
 }
@@ -523,6 +525,9 @@ func (c *MtnState) BindAllocs(ctx context.Context, netId string) error {
 }
 
 func (c *MtnState) UseAlloc(ctx context.Context, netId string, box string, ident string) (Allocation, error) {
+	c.AllocMu.Lock()
+	defer c.AllocMu.Unlock()
+	log.G(ctx).Debugf("UseAlloc() successfuly get lock for: %s %s %s.", netId, box, ident)
 	tx, errTx := c.Db.Begin(true)
 	if errTx != nil {
 		log.G(ctx).Errorf("Cant start transaction inside UseAlloc(), err: %s", errTx)


### PR DESCRIPTION
Because BoltDB not have support for construction like 'upsert if value is'  we need internal lock at allocation state. 